### PR TITLE
Fix a diffusion loss bug

### DIFF
--- a/policy_models/VPP_policy.py
+++ b/policy_models/VPP_policy.py
@@ -256,12 +256,12 @@ class VPP_Policy(pl.LightningModule):
 
         predictive_feature, latent_goal= self.extract_predictive_feature(dataset_batch)
 
-        act_loss, sigmas, noise = self.diffusion_loss(
+        target, model_output = self.diffusion_loss(
             predictive_feature,
             latent_goal,
             dataset_batch["actions"],
         )
-
+        act_loss = (model_output - target).pow(2).flatten(1).mean()
         action_loss += act_loss
         total_loss += act_loss
 

--- a/policy_models/VPP_policy_xbot.py
+++ b/policy_models/VPP_policy_xbot.py
@@ -258,7 +258,7 @@ class VPP_Policy(nn.Module):#pl.LightningModule):
             latent_goal,
             dataset_batch["actions"],
         )
-        act_loss = (model_output - target).pow(2).flatten(1).mean(),
+        act_loss = (model_output - target).pow(2).flatten(1).mean()
 
         action_loss += act_loss
         total_loss += act_loss

--- a/policy_models/edm_diffusion/score_wrappers.py
+++ b/policy_models/edm_diffusion/score_wrappers.py
@@ -73,13 +73,14 @@ class GCDenoiser(nn.Module):
             sigma: The input sigma.
             **kwargs: Additional keyword arguments.
         Returns:
-            The computed loss.
+            The target and model_output. Note that the loss will be calculated outside
+            of this function to provide more flexibility in customization.
         """
         c_skip, c_out, c_in = [append_dims(x, action.ndim) for x in self.get_scalings(sigma)]
         noised_input = action + noise * append_dims(sigma, action.ndim)
         model_output = self.inner_model(state, noised_input * c_in, goal, sigma, **kwargs)
         target = (action - c_skip * noised_input) / c_out
-        return (model_output - target).pow(2).flatten(1).mean(), model_output
+        return target, model_output
 
     def forward(self, state, action, goal, sigma, **kwargs):
         """


### PR DESCRIPTION
This PR fixes a diffusion loss calculation bug.

The issue impacts multiple places where the ``self.diffusion_loss`` is called.

This issue affects several places in the code base. As one example, we expect the diffusion_loss function return a ``target`` and ``model_output`` for l2 loss calculation:

https://github.com/roboterax/video-prediction-policy/blob/75cf37ad0f537627e1a3aa9a04bab70324ec27ff/policy_models/VPP_policy_xbot.py#L256-L262

However, what actually being returned are the **loss** and ``model_output``:

https://github.com/roboterax/video-prediction-policy/blob/75cf37ad0f537627e1a3aa9a04bab70324ec27ff/policy_models/edm_diffusion/score_wrappers.py#L81-L82

This PR fixes this bug.